### PR TITLE
Gainers and losers on the dashboard

### DIFF
--- a/runconsole_test.bat
+++ b/runconsole_test.bat
@@ -1,0 +1,1 @@
+dotnet run --project src\FinvizScraper.Console config\config_secret.json --test-reports

--- a/src/FinvizScraper.Console/Program.fs
+++ b/src/FinvizScraper.Console/Program.fs
@@ -30,6 +30,9 @@ let runIndustryUpdates() =
 let runScreeners() =
     containsArgument "--screeners"
 
+let runTestReports() =
+    containsArgument "--test-reports"
+
 let fetchScreenerResults (input:ScreenerInput) =
     Console.WriteLine("Processing " + input.name)
     Console.WriteLine("fetching results...")
@@ -56,6 +59,7 @@ match config.dbConnectionString with
     Environment.Exit(-1)
 | value -> 
     value |> Storage.configureConnectionString
+    value |> Reports.configureConnectionString
 
 match runScreeners() with
 | true ->
@@ -70,6 +74,7 @@ match runScreeners() with
     Storage.saveJobStatus ScreenerJob (DateTimeOffset.UtcNow) Success $"Ran {screenerResults.Length} screeners" |> ignore
 
 | false -> ()
+
 
 match runIndustryUpdates() with
 | true ->     
@@ -94,3 +99,14 @@ match runIndustryUpdates() with
     Storage.saveJobStatus IndustryTrendsJob (DateTimeOffset.UtcNow) Success $"Updated trends for {updateCount} industries" |> ignore
 
 | false -> ()
+
+
+match runTestReports() with
+| true -> 
+    let results = Reports.getTopIndustriesForScreener FinvizConfig.NewHighsScreener 14
+    Console.WriteLine(results)
+
+    let results = Reports.getTopIndustriesForScreener FinvizConfig.NewLowsScreener 14
+    Console.WriteLine(results)
+
+| false -> Console.WriteLine("I will not run reports")

--- a/src/FinvizScraper.Console/Program.fs
+++ b/src/FinvizScraper.Console/Program.fs
@@ -109,4 +109,4 @@ match runTestReports() with
     let results = Reports.getTopIndustriesForScreener FinvizConfig.NewLowsScreener 14
     Console.WriteLine(results)
 
-| false -> Console.WriteLine("I will not run reports")
+| false -> ()

--- a/src/FinvizScraper.Core/Types.fs
+++ b/src/FinvizScraper.Core/Types.fs
@@ -31,6 +31,8 @@ type FinvizConfig =
         System.DateTime.Now |> FinvizConfig.formatRunDate 
 
     static member dayRange = 31
+    static member industryTrendDayRange = 14
+    static member sectorTrendDayRange = 14
     
     // TODO: not sure how to make these more dynamic. We need some custom logic
     // for certain reports that refer to screeners by id

--- a/src/FinvizScraper.Storage/Reports.fs
+++ b/src/FinvizScraper.Storage/Reports.fs
@@ -273,3 +273,57 @@ module Reports =
                     "@limit", Sql.int limit
                 ]
                 |> Sql.execute mapScreenerResultReportItem
+
+    let getTopIndustriesForScreener id days =
+
+        let sql = @$"
+            SELECT 
+                industry,count(DISTINCT stocks.ticker) as count
+            FROM screenerresults
+            JOIN stocks ON stocks.id = screenerresults.stockid
+            WHERE 
+                screenerresults.screenerid = @screenerid
+                AND screenerresults.date >= current_date - @days
+            GROUP BY industry
+            ORDER BY count DESC"
+
+        cnnString
+            |> Sql.connect
+            |> Sql.query sql
+            |> Sql.parameters [
+                "@screenerid", Sql.int id;
+                "@days", Sql.int days
+            ]
+            |> Sql.execute (fun reader -> 
+                (
+                    reader.string "industry",
+                    reader.int "count"
+                )
+            )
+
+    let getTopSectorsForScreener id days =
+
+        let sql = @$"
+            SELECT 
+                sector,count(DISTINCT stocks.ticker) as count
+            FROM screenerresults
+            JOIN stocks ON stocks.id = screenerresults.stockid
+            WHERE 
+                screenerresults.screenerid = @screenerid
+                AND screenerresults.date >= current_date - @days
+            GROUP BY sector
+            ORDER BY count DESC"
+
+        cnnString
+            |> Sql.connect
+            |> Sql.query sql
+            |> Sql.parameters [
+                "@screenerid", Sql.int id;
+                "@days", Sql.int days
+            ]
+            |> Sql.execute (fun reader -> 
+                (
+                    reader.string "sector",
+                    reader.int "count"
+                )
+            )

--- a/src/FinvizScraper.Web/Handlers/Dashboard.fs
+++ b/src/FinvizScraper.Web/Handlers/Dashboard.fs
@@ -17,7 +17,7 @@ module Dashboard =
                 Views.generateHrefWithAttr
                     $"{screener.count}"
                     (Links.screenerResultsLink (screener.screenerid) screenerDate)
-                    (_class "button is-primary mr-2 width50")
+                    (_class "button is-primary mr-2")
 
                 str screener.name
             ]

--- a/src/FinvizScraper.Web/Shared/Views.fs
+++ b/src/FinvizScraper.Web/Shared/Views.fs
@@ -60,7 +60,7 @@ module Views =
             |> List.map (fun (name,count) ->
                 tr [] [
                     td [] [ (nameElementFunc name) ]
-                    td [] [ str (count.ToString()) ]
+                    td [ _class "has-text-right"] [ str (count.ToString()) ]
                 ])
 
         let header = tr [] [

--- a/tests/ReportTests.fs
+++ b/tests/ReportTests.fs
@@ -142,3 +142,19 @@ type ReportTests(output:ITestOutputHelper) =
         let results = FinvizScraper.Storage.Reports.getDailyCountsForScreenerAndCountry screener.Value.id industry 30
         
         Assert.NotEmpty(results)
+
+    [<Fact>]
+    let ``getting trending industries works``() =
+        let results = 
+            FinvizScraper.Storage.Reports.getTopIndustriesForScreener
+                FinvizScraper.Core.FinvizConfig.NewHighsScreener 14
+
+        Assert.NotEmpty(results)
+
+    [<Fact>]
+    let ``getting trending sectors works``() =
+        let results = 
+            FinvizScraper.Storage.Reports.getTopSectorsForScreener
+                FinvizScraper.Core.FinvizConfig.NewHighsScreener 14
+
+        Assert.NotEmpty(results)


### PR DESCRIPTION
Add a high level gainers and losers per industry and sector on the dashboard. Simplify the dashboard itself to show each screener with counts only, no breakdowns.