### PR TITLE
Track daily SMA trend

### DIFF
--- a/db.sql
+++ b/db.sql
@@ -43,7 +43,7 @@ create table industryupdates (
     above numeric not null,
     below numeric not null,
     UNIQUE(industry, "date")
-);quit
+);
 
 alter table industryupdates add column days numeric;
 UPDATE industryupdates SET days = 20;
@@ -64,3 +64,22 @@ create table industrysmabreakdowns ( like industryupdates INCLUDING DEFAULTS INC
 insert into industrysmabreakdowns SELECT * FROM industryupdates;
 
 drop table industryupdates cascade;
+
+create sequence industrysmabreakdowns_id_seq;
+alter table industrysmabreakdowns alter column id set default nextval('industrysmabreakdowns_id_seq');
+
+-- set industrysmabreakdowns_id_seq to be max id value of industrysmabreakdowns
+select setval('industrysmabreakdowns_id_seq', (select max(id) from industrysmabreakdowns));
+
+-- set id as primary key of industrysmabreakdowns
+alter table industrysmabreakdowns add primary key (id);
+
+
+create table dailysmabreakdowns (
+    id serial primary key,
+    "date" timestamp not null,
+    above numeric not null,
+    below numeric not null,
+    days numeric not null,
+    UNIQUE(days, "date")
+);

--- a/src/FinvizScraper.Console/Program.fs
+++ b/src/FinvizScraper.Console/Program.fs
@@ -109,6 +109,8 @@ match runSMAUpdates() with
 
 match runTestReports() with
 | true -> 
+
+    // used this to migrate some data, but it's not needed anymore
     [0..60]
     |> List.map (fun i -> DateTime.UtcNow.AddDays(-i))
     |> List.filter (fun date -> (date.DayOfWeek = System.DayOfWeek.Sunday |> not) && (date.DayOfWeek = System.DayOfWeek.Saturday |> not))  // business days only
@@ -124,12 +126,11 @@ match runTestReports() with
                 Console.WriteLine($"No {days} day SMA breakdowns for {date}")
         )
     )
-    // let results = Constants.NewHighsScreenerId |> Reports.getTopIndustriesForScreener 14
-    // Console.WriteLine(results)
 
-    // let results = Constants.NewLowsScreenerId |> Reports.getTopIndustriesForScreener 14
-    // Console.WriteLine(results)
-    
-    ()
+    let results = Constants.NewHighsScreenerId |> Reports.getTopIndustriesForScreener 14
+    Console.WriteLine(results)
+
+    let results = Constants.NewLowsScreenerId |> Reports.getTopIndustriesForScreener 14
+    Console.WriteLine(results)
 
 | false -> ()

--- a/src/FinvizScraper.Core/Types.fs
+++ b/src/FinvizScraper.Core/Types.fs
@@ -62,7 +62,7 @@ type FinvizConfig =
             | Constants.TopGainerScreenerId -> "#4DBEF7" // top gainer
             | Constants.TopLoserScreenerId -> "#C54A8B" // top loser
             | Constants.NewLowsScreenerId -> "#90323C" // new low
-            | _ -> FinvizConfig.getBackgroundColorDefault // otherwise blow up
+            | _ -> FinvizConfig.getBackgroundColorDefault // otherwise return default
 
 type ScreenerResult = {
     ticker:StockTicker.T;

--- a/src/FinvizScraper.Core/Types.fs
+++ b/src/FinvizScraper.Core/Types.fs
@@ -52,6 +52,8 @@ type FinvizConfig =
     static member dayRange = 61
     static member industryTrendDayRange = 14
     static member sectorTrendDayRange = 14
+
+    static member getBackgroundColorDefault = "#FF6586"
     
     static member getBackgroundColorForScreenerId id =
         match id with
@@ -60,9 +62,7 @@ type FinvizConfig =
             | Constants.TopGainerScreenerId -> "#4DBEF7" // top gainer
             | Constants.TopLoserScreenerId -> "#C54A8B" // top loser
             | Constants.NewLowsScreenerId -> "#90323C" // new low
-            | _ -> raise (new System.Exception($"Unknown screener id {id} for screener tags")) // otherwise blow up
-
-    static member getBackgroundColorDefault = "#FF6586"
+            | _ -> FinvizConfig.getBackgroundColorDefault // otherwise blow up
 
 type ScreenerResult = {
     ticker:StockTicker.T;
@@ -91,9 +91,8 @@ type Screener = {
     url: string;
 }
 
-type IndustrySMABreakdown =
+type SMABreakdown =
     {
-        industry: string;
         date: System.DateTime;
         days: int;
         above: int;
@@ -106,6 +105,12 @@ type IndustrySMABreakdown =
         match this.total with
             | 0 -> 0.0
             | _ -> (float this.above ) * 100.0 / (float this.total)
+
+type IndustrySMABreakdown = 
+    {
+        industry: string;
+        breakdown: SMABreakdown;
+    }
 
 type JobStatus =
     | Success

--- a/src/FinvizScraper.Web/Handlers/Dashboard.fs
+++ b/src/FinvizScraper.Web/Handlers/Dashboard.fs
@@ -6,7 +6,6 @@ module Dashboard =
     open FinvizScraper.Storage.Reports
     open FinvizScraper.Web.Shared
     open FinvizScraper.Core
-    open FinvizScraper.Storage.Storage
 
     let private generateScreenerResultSection (screener:ScreenerResultReport) = 
         
@@ -105,6 +104,23 @@ module Dashboard =
             ]
         ]
 
+    let private generateSMATrendRows() =
+
+        let numberOfPoints = 40
+        let sma20 = getDailySMABreakdown 20 numberOfPoints
+        let sma200 = getDailySMABreakdown 200 numberOfPoints
+    
+        [ ("SMA 20", sma20); ("SMA 200", sma200) ]
+            |> List.map (fun (title, data) ->
+                data
+                |> List.rev
+                |> List.map (fun breakdown ->
+                    (breakdown.date, System.Math.Round(breakdown.percentAbove, 0))
+                )
+                |> Charts.convertNameCountsToChart title Charts.Line (Some 100) Charts.smallChart FinvizConfig.getBackgroundColorDefault
+                |> div [_class "block"] 
+            )
+
     let private createView (screeners:list<ScreenerResultReport>) =
         
         let screenerRows = screeners |> List.map generateScreenerResultSection
@@ -112,9 +128,11 @@ module Dashboard =
         let industryTrendRows = generateIndustryTrendsRow FinvizConfig.industryTrendDayRange
         let sectorTrendRows = generateSectorTrendsRow FinvizConfig.sectorTrendDayRange
 
+        let smaTrendRows = generateSMATrendRows()
+
         let jobStatusRow = generateJobStatusRow()
 
-        screenerRows @ industryTrendRows @ sectorTrendRows @ [ jobStatusRow ]
+        screenerRows @ smaTrendRows @ industryTrendRows @ sectorTrendRows @ [ jobStatusRow ]
 
     let handler()  = 
         

--- a/src/FinvizScraper.Web/Handlers/IndustriesDashboard.fs
+++ b/src/FinvizScraper.Web/Handlers/IndustriesDashboard.fs
@@ -24,14 +24,14 @@ module IndustriesDashboard =
             |> Map.toList
             |> List.sortByDescending (fun (key, update200) -> 
                 let update20 = industrySMABreakdowns20[key]
-                (update200.percentAbove, update20.percentAbove)
+                (update200.breakdown.percentAbove, update20.breakdown.percentAbove)
             )
             |> List.map (fun (key, iu) ->
 
                 let toSMACells (update:FinvizScraper.Core.IndustrySMABreakdown) =
                     [
-                        td [] [ update.above.ToString() |> str  ]
-                        td [] [ System.String.Format("{0:N2}%", update.percentAbove) |> str ]
+                        td [] [ update.breakdown.above.ToString() |> str  ]
+                        td [] [ System.String.Format("{0:N2}%", update.breakdown.percentAbove) |> str ]
                     ]
 
                 let sma20Cells = toSMACells (industrySMABreakdowns20[key])
@@ -47,7 +47,7 @@ module IndustriesDashboard =
                             iu.industry |> Links.industryFinvizLink |> generateHrefNewTab "finviz" 
                         ]
                     ]
-                    td [] [(iu.total).ToString() |> str]
+                    td [] [(iu.breakdown.total).ToString() |> str]
                 ]
 
                 let cells = List.append (List.append commonCells sma20Cells) sma200Cells

--- a/src/FinvizScraper.Web/Handlers/IndustryDashboard.fs
+++ b/src/FinvizScraper.Web/Handlers/IndustryDashboard.fs
@@ -16,9 +16,9 @@ module IndustryDashboard =
                 match trend with
                 | None -> "No 20 SMA trends found"
                 | Some t -> 
-                    let total = t.above + t.below
-                    let pct = System.Math.Round((double t.above) * 100.0 / (double total), 2)
-                    $"<b>{pct}%%</b> ({t.above} / {total}) above {t.days} SMA"
+                    let total = t.breakdown.above + t.breakdown.below
+                    let pct = System.Math.Round((double t.breakdown.above) * 100.0 / (double total), 2)
+                    $"<b>{pct}%%</b> ({t.breakdown.above} / {total}) above {t.breakdown.days} SMA"
 
             span [ _class "mx-1"] [
                 rawText desc
@@ -34,7 +34,7 @@ module IndustryDashboard =
             let industryTrendChartsInternal days =
                 industryName
                 |> Reports.getIndustrySMABreakdownsForIndustry days
-                |> List.map (fun u -> (u.date,System.Math.Round(u.percentAbove, 0)))
+                |> List.map (fun u -> (u.breakdown.date,System.Math.Round(u.breakdown.percentAbove, 0)))
                 |> Charts.convertNameCountsToChart $"{days} EMA Trend" Charts.Line (Some 100) Charts.smallChart FinvizConfig.getBackgroundColorDefault 
 
             (industryTrendChartsInternal 20) @ (industryTrendChartsInternal 200)

--- a/tests/StorageTests.fs
+++ b/tests/StorageTests.fs
@@ -162,3 +162,17 @@ type StorageTests(output:ITestOutputHelper) =
 
         Assert.Equal(message, latestMessage)
         Assert.Equal(timestamp.DateTime, latestTimestamp.DateTime, (System.TimeSpan.FromMilliseconds(1)))
+
+    [<Fact>]
+    let ``daily sma breakdown works`` () =
+
+        // go back to the previous business day
+        let date =
+            match System.DateTime.UtcNow.DayOfWeek with
+            | System.DayOfWeek.Monday -> System.DateTime.UtcNow.AddDays(-3)
+            | System.DayOfWeek.Sunday -> System.DateTime.UtcNow.AddDays(-2)
+            | _ -> System.DateTime.UtcNow.AddDays(-1)
+
+        let updated = Storage.updateSMABreakdowns (date |> FinvizConfig.formatRunDate) 20
+
+        Assert.Equal(1, updated)


### PR DESCRIPTION
Experimenting with tracking SMA 20/200 trend over time and rendering that on the dashboard.

To make this happen had to extend the daily industry sma breakdown job to store the total breakdown as well.

Ended changing the type used for sma breakdowns so that industry breakdown and a general breakdown can reuse the type. As a result some refactoring had to be done in other pages.