### PR TITLE
Render earnings icon next to screener results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ cache/
 .fake
 .vscode/
 *secret*
+node_modules/
 
 *.json

--- a/db.sql
+++ b/db.sql
@@ -97,7 +97,8 @@ create table industrytrends (
 
 
 create table earnings (
-    ticker text not null primary key,
+    ticker text not null,
     "date" timestamp not null,
-    earningstime text not null
+    earningstime text not null,
+    primary key (ticker, "date")
 );

--- a/db.sql
+++ b/db.sql
@@ -94,3 +94,10 @@ create table industrytrends (
     days numeric not null,
     UNIQUE(industry, days)
 );
+
+
+create table earnings (
+    ticker text not null primary key,
+    "date" timestamp not null,
+    earningstime text not null
+);

--- a/src/FinvizScraper.Console/Program.fs
+++ b/src/FinvizScraper.Console/Program.fs
@@ -65,10 +65,10 @@ match config.dbConnectionString with
 match runScreeners() with
 | true ->
     
-    // let screenerResults =
-    //     Storage.getScreeners()
-    //     |> List.map fetchScreenerResults
-    //     |> saveToDb
+    let screenerResults =
+        Storage.getScreeners()
+        |> List.map fetchScreenerResults
+        |> saveToDb
 
     let earnings = FinvizClient.getEarnings()
 
@@ -78,7 +78,7 @@ match runScreeners() with
             Storage.saveEarningsDate ticker (Utils.getRunDate()) earningsTime |> ignore
         )
     
-    // Storage.saveJobStatus ScreenerJob (DateTimeOffset.UtcNow) Success $"Ran {screenerResults.Length} screeners" |> ignore
+    Storage.saveJobStatus ScreenerJob (DateTimeOffset.UtcNow) Success $"Ran {screenerResults.Length} screeners" |> ignore
 
 | false -> ()
 

--- a/src/FinvizScraper.Console/Program.fs
+++ b/src/FinvizScraper.Console/Program.fs
@@ -65,12 +65,20 @@ match config.dbConnectionString with
 match runScreeners() with
 | true ->
     
-    let screenerResults =
-        Storage.getScreeners()
-        |> List.map fetchScreenerResults
-        |> saveToDb
+    // let screenerResults =
+    //     Storage.getScreeners()
+    //     |> List.map fetchScreenerResults
+    //     |> saveToDb
+
+    let earnings = FinvizClient.getEarnings()
+
+    earnings
+        |> List.iter (fun x ->
+            let (ticker,earningsTime) = x
+            Storage.saveEarningsDate ticker (Utils.getRunDate()) earningsTime |> ignore
+        )
     
-    Storage.saveJobStatus ScreenerJob (DateTimeOffset.UtcNow) Success $"Ran {screenerResults.Length} screeners" |> ignore
+    // Storage.saveJobStatus ScreenerJob (DateTimeOffset.UtcNow) Success $"Ran {screenerResults.Length} screeners" |> ignore
 
 | false -> ()
 

--- a/src/FinvizScraper.Core/Types.fs
+++ b/src/FinvizScraper.Core/Types.fs
@@ -144,3 +144,7 @@ type JobName =
     | ScreenerJob
     | IndustryTrendsJob
     | TestJob
+
+type EarningsTime =
+    | BeforeMarket
+    | AfterMarket

--- a/src/FinvizScraper.Core/Utils.fs
+++ b/src/FinvizScraper.Core/Utils.fs
@@ -16,6 +16,14 @@ namespace FinvizScraper.Core
             | DayOfWeek.Sunday -> newDate.AddDays(1)
             | _ -> newDate
 
+        let subtractDaysToClosestBusinessDay (date:System.DateTime) days =
+            let newDate = date.AddDays(-days)
+
+            match newDate.DayOfWeek with
+            | DayOfWeek.Saturday -> newDate.AddDays(-1)
+            | DayOfWeek.Sunday -> newDate.AddDays(-2)
+            | _ -> newDate
+
         let convertToDateString (date:DateTime) =
             date.ToString("yyyy-MM-dd")
 

--- a/src/FinvizScraper.FinvizClient/FinvizClient.fs
+++ b/src/FinvizScraper.FinvizClient/FinvizClient.fs
@@ -146,3 +146,10 @@ module FinvizClient =
         let below20 = $"ta_sma{days}_pb" |> fetchCountWithTA
 
         (above20,below20)
+
+    let getEarnings() =
+        
+        let before = getResults "https://finviz.com/screener.ashx?v=111&s=n_earningsbefore" |> List.map (fun r -> r.ticker, BeforeMarket)
+        let after = getResults "https://finviz.com/screener.ashx?v=111&s=n_earningsafter" |> List.map (fun r -> r.ticker, AfterMarket)
+
+        List.concat [before; after]

--- a/src/FinvizScraper.Storage/Reports.fs
+++ b/src/FinvizScraper.Storage/Reports.fs
@@ -203,6 +203,19 @@ module Reports =
                 mapScreenerResultReportItem reader
             )
 
+    let getTickersWithEarnings date =
+        let sql = @$"SELECT ticker FROM earnings
+            WHERE date = date(@date)"
+        let results =
+            cnnString
+            |> Sql.connect
+            |> Sql.query sql
+            |> Sql.parameters [
+                "@date", Sql.string date
+            ]
+            |> Sql.execute (fun reader -> reader.string "ticker")
+        results
+    
     let getScreenerResults id date =
 
         let sql = @$"

--- a/src/FinvizScraper.Storage/Storage.fs
+++ b/src/FinvizScraper.Storage/Storage.fs
@@ -298,7 +298,7 @@ module Storage =
 
     let saveEarningsDate ticker date earningsTime =
         let sql = @"INSERT INTO earnings (ticker,date,earningsTime) VALUES (@ticker,date(@date),@earningsTime)
-            ON CONFLICT (ticker) DO UPDATE SET earningsTime = @earningsTime, date = date(@date)"
+            ON CONFLICT (ticker,date) DO NOTHING"
         cnnString
         |> Sql.connect
         |> Sql.query sql

--- a/src/FinvizScraper.Storage/Storage.fs
+++ b/src/FinvizScraper.Storage/Storage.fs
@@ -42,6 +42,11 @@ module Storage =
             | Success _ -> "success"
             | Failure _ -> "failure"
 
+    let private toEarningTimeString earningsTime =
+        match earningsTime with
+            | BeforeMarket _ -> "beforemarket"
+            | AfterMarket _ -> "aftermarket"
+
     let singleOrThrow message results =
         match results with
         | [] -> None
@@ -288,6 +293,19 @@ module Storage =
             "@days", Sql.int days;
             "@above", Sql.int above;
             "@below", Sql.int below;
+        ]
+        |> Sql.executeNonQuery
+
+    let saveEarningsDate ticker date earningsTime =
+        let sql = @"INSERT INTO earnings (ticker,date,earningsTime) VALUES (@ticker,date(@date),@earningsTime)
+            ON CONFLICT (ticker) DO UPDATE SET earningsTime = @earningsTime, date = date(@date)"
+        cnnString
+        |> Sql.connect
+        |> Sql.query sql
+        |> Sql.parameters [
+            "@ticker", ticker |> StockTicker.value |> Sql.string;
+            "@date", Sql.string date;
+            "@earningsTime", earningsTime |> toEarningTimeString |> Sql.string
         ]
         |> Sql.executeNonQuery
 

--- a/src/FinvizScraper.Web/Handlers/ScreenerDashboard.fs
+++ b/src/FinvizScraper.Web/Handlers/ScreenerDashboard.fs
@@ -79,7 +79,7 @@ module ScreenerDashboard =
 
         let resultsTable =
             results
-            |> ScreenerResults.generateScreenerResultTable
+            |> ScreenerResults.generateScreenerResultTable []
 
         headerWithCharts @ breakdownElements @ [resultsTable]
 

--- a/src/FinvizScraper.Web/Shared/Views.fs
+++ b/src/FinvizScraper.Web/Shared/Views.fs
@@ -164,6 +164,11 @@ module Views =
                     Links.bulmaCssLink |> _href
                 ]
 
+                link [
+                    _rel "stylesheet"
+                    "/node_modules/@fortawesome/fontawesome-free/css./all.min.css" |> _href
+                ]
+
                 script [ Links.chartJsLink |> _src ] []
                 script [ Links.chartJsDatalabelsLink |> _src ] []
                 script [ Links.sortingJsLink |> _src ] []

--- a/tests/ReportTests.fs
+++ b/tests/ReportTests.fs
@@ -289,3 +289,8 @@ type ReportTests(output:ITestOutputHelper) =
     let ``get industry trend works`` () =
         let trend = Reports.getIndustryTrend 20 StorageTests.testStockIndustry
         Assert.True(trend.IsSome)
+
+    [<Fact>]
+    let ``get tickers with earnings works`` () =
+        let results = Reports.getTickersWithEarnings "2022-08-18"
+        Assert.NotEmpty(results)

--- a/tests/UtilsTests.fs
+++ b/tests/UtilsTests.fs
@@ -1,0 +1,38 @@
+module UtilsTests
+
+open Xunit
+open Xunit.Abstractions
+open System
+open FinvizScraper.Core
+
+type UtilsTests(output:ITestOutputHelper) =
+
+    [<Fact>]
+    let ``runDate tests`` () =
+        let todayExplicitly = DateTime.UtcNow |> Utils.convertToDateString
+        let todayImplicitly = Utils.getRunDate()
+
+        Assert.Equal(todayExplicitly, todayImplicitly)
+
+    [<Theory>]
+    [<InlineData("A & E", "ae")>]
+    [<InlineData("Technology", "technology")>]
+    let ``cleanIndustry tests`` (industry:string) (expected:string) =
+        let cleaned = Utils.cleanIndustry industry
+        Assert.Equal(expected, cleaned)
+
+    [<Fact>]
+    let ``add business days to Friday should return monday`` () =
+
+        let friday = DateTime.ParseExact("2022-04-01", "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)
+        let nextBusinessDay = Utils.addDaysToClosestBusinessDay friday 1
+
+        Assert.Equal("2022-04-04", nextBusinessDay |> Utils.convertToDateString)
+
+    [<Fact>]
+    let ``subtract business days to Monday should return Friday`` () =
+
+        let monday = DateTime.ParseExact("2022-04-04", "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture)
+        let previousBusinessDay = Utils.subtractDaysToClosestBusinessDay monday 1
+
+        Assert.Equal("2022-04-01", previousBusinessDay |> Utils.convertToDateString)

--- a/tests/tests.fsproj
+++ b/tests/tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="StorageTests.fs" />
     <Compile Include="ReportTests.fs" />
     <Compile Include="FinvizClientTests.fs" />
+    <Compile Include="UtilsTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
When viewing screener results, if the ticker has had earnings that day (or day before), show the earnings icon.

<img width="714" alt="image" src="https://user-images.githubusercontent.com/911757/185487506-67310be1-f22d-4455-b575-e45da699b117.png">
