### PR TITLE
Use discriminated union to represent SMAs

### DIFF
--- a/src/StockScreenerReports.Console/Program.fs
+++ b/src/StockScreenerReports.Console/Program.fs
@@ -89,10 +89,10 @@ match runCyclesMigration() with
     |> Seq.iter (fun industry -> 
         
         let range = ReportsConfig.dateRangeAsStrings()
-        let breakdowns = industry |> Reports.getIndustrySMABreakdownsForIndustry 20 range
+        let breakdowns = industry |> Reports.getIndustrySMABreakdownsForIndustry SMA20 range
         let trendWithCycle = breakdowns |> TrendsCalculator.calculateForIndustry
         let cycle = trendWithCycle.cycle
-        industry |> Storage.saveIndustryCycle 20 cycle |> ignore
+        industry |> Storage.saveIndustryCycle SMA20 cycle |> ignore
 
     )|> ignore
     
@@ -109,7 +109,7 @@ match runTestReports() with
 
     let smaBreakdowns = 
         industry
-        |> Reports.getIndustrySMABreakdownsForIndustry 20 (ReportsConfig.dateRangeAsStrings())
+        |> Reports.getIndustrySMABreakdownsForIndustry SMA20 (ReportsConfig.dateRangeAsStrings())
 
     smaBreakdowns
     |> List.iter (fun x -> Console.Write($"({x.breakdown.above}, {x.breakdown.above + x.breakdown.below});"))

--- a/src/StockScreenerReports.Web/Handlers/Analysis.fs
+++ b/src/StockScreenerReports.Web/Handlers/Analysis.fs
@@ -57,7 +57,7 @@ module Analysis =
                     )
 
                 let industryMarketCycles =
-                    Constants.SMA20
+                    SMA20
                     |> Storage.getIndustryCycles
                     |> Map.ofList
 

--- a/src/StockScreenerReports.Web/Handlers/Countries.fs
+++ b/src/StockScreenerReports.Web/Handlers/Countries.fs
@@ -59,7 +59,7 @@ module Countries =
             | None -> HtmlElements.div [] [ HtmlElements.str "No data available to chart"]
             | Some dailyBreakdowns ->
                 
-                let smaInterval = 20
+                let sma = SMA20
                 
                 let dataset : Charts.DataSet<decimal> =
                     let series = 
@@ -68,8 +68,8 @@ module Countries =
                         
                     {
                         data = series
-                        title = $"{smaInterval} SMA Trend"
-                        color = smaInterval |> Constants.mapSmaToColor
+                        title = $"{sma |> SMA.toInterval} SMA Trend"
+                        color = sma |> SMA.toColor
                     }
                     
                     
@@ -164,12 +164,12 @@ module Countries =
             let formattedDate = latestDate |> Utils.convertToDateString
             let dateRange = ReportsConfig.dateRangeAsStrings()
             
-            let countrySMABreakdowns20Map = Reports.getCountrySMABreakdowns Constants.SMA20 formattedDate |> toBreakdownMap
-            let countrySMABreakdowns200Map = Reports.getCountrySMABreakdowns Constants.SMA200 formattedDate |> toBreakdownMap
+            let countrySMABreakdowns20Map = Reports.getCountrySMABreakdowns SMA20 formattedDate |> toBreakdownMap
+            let countrySMABreakdowns200Map = Reports.getCountrySMABreakdowns SMA200 formattedDate |> toBreakdownMap
             let dailySMABreakdownMap =
                 countries
                 |> List.map (fun country ->
-                    let breakdowns = country |> Reports.getCountrySMABreakdownsForCountry Constants.SMA20 dateRange
+                    let breakdowns = country |> Reports.getCountrySMABreakdownsForCountry SMA20 dateRange
                     (country, breakdowns)
                 )
                 |> Map.ofList

--- a/src/StockScreenerReports.Web/Handlers/CountryDashboard.fs
+++ b/src/StockScreenerReports.Web/Handlers/CountryDashboard.fs
@@ -69,11 +69,11 @@ module CountryDashboard =
                     {
                         data = series
                         title = $"{sma} SMA Trend"
-                        color = sma |> Constants.mapSmaToColor
+                        color = sma |> SMA.toColor
                     }
                     
                 dataset
-                )
+            )
             
         let _, breakdowns = dailySMABreakdowns[0]
 
@@ -108,7 +108,7 @@ module CountryDashboard =
             )
             
         let smaChart =
-            Constants.SMAS
+            SMA.all
             |> List.map (fun sma -> sma, countryName)
             |> List.map (fun (sma, countryName) -> sma, countryName |> getCountrySMABreakdownsForCountry sma dateRangeAsStrings)
             |> renderSMAChart

--- a/src/StockScreenerReports.Web/Handlers/Cycles.fs
+++ b/src/StockScreenerReports.Web/Handlers/Cycles.fs
@@ -195,7 +195,7 @@ module Cycles =
                 cycle.rateOfChange >= minimumRateOfChange
 
             let cycles =
-                Constants.SMA20
+                SMA20
                 |> Storage.getIndustryCycles
 
             // get latest job runs 

--- a/src/StockScreenerReports.Web/Handlers/Dashboard.fs
+++ b/src/StockScreenerReports.Web/Handlers/Dashboard.fs
@@ -27,7 +27,7 @@ module Dashboard =
             a [
                 _class "button is-primary is-fullwidth"
                 _style "justify-content: left;"
-                _href (Links.screenerResultsLink (screener.screenerid) screenerDate)] [
+                _href (Links.screenerResultsLink screener.screenerid screenerDate)] [
                 span [
                     _style "font-size: 1.5em; font-weight: bold; padding-right: 10px"
                 ] [
@@ -92,8 +92,8 @@ module Dashboard =
         div [_class "columns"] columns |> Views.toSection "Sector Trends"
 
     let private generateSMATrendRows smaTrendCyclePairs =
-        let mapTrendToHtml (sma:int) (trend:Trend) =
-            $"SMA <b>{sma}</b>: {trend |> Views.trendToHtml}"
+        let mapTrendToHtml (sma:SMA) (trend:Trend) =
+            $"SMA <b>{sma |> SMA.toInterval}</b>: {trend |> Views.trendToHtml}"
 
         let mapMarketCycleToHtml (cycle:MarketCycle) =
             $"Market cycle: {cycle |> Views.marketCycleToHtml}"
@@ -101,7 +101,7 @@ module Dashboard =
         let columns =
             smaTrendCyclePairs
                     |> List.map (fun (sma, trendWithCycle) ->
-                        let hasTextRight = match sma with | Constants.SMA200 -> "has-text-right" | _ -> ""
+                        let hasTextRight = match sma with | SMA200 -> "has-text-right" | _ -> ""
 
                         let trend = trendWithCycle.trend
                         let cycle = trendWithCycle.cycle
@@ -126,11 +126,11 @@ module Dashboard =
 
         let datasets:list<Charts.DataSet<decimal>> =
             breakdowns
-            |> List.map (fun (sma, (smaBreakdown:list<SMABreakdown>)) ->
+            |> List.map (fun (sma, smaBreakdown:list<SMABreakdown>) ->
                 {
                     data = smaBreakdown |> List.map (fun breakdown -> breakdown.percentAboveRounded)
                     title = $"SMA {sma}"
-                    color = sma |> Constants.mapSmaToColor
+                    color = sma |> SMA.toColor
                 }   
             )
 
@@ -185,7 +185,7 @@ module Dashboard =
         // end sector trends
 
         let breakdowns =
-            Constants.SMAS
+            SMA.all
             |> List.map (fun sma ->
                 let smaBreakdown = sma |> getDailySMABreakdown (ReportsConfig.dateRangeAsStrings())
                 (sma, smaBreakdown)
@@ -202,12 +202,12 @@ module Dashboard =
         // trend rows
         
         // SMA breakdown charts
-        let (smaBreakdownChartSection, smaBreakdownSmoothedChartSection) = generateSMABreakdownRows breakdowns
+        let smaBreakdownChartSection, smaBreakdownSmoothedChartSection = generateSMABreakdownRows breakdowns
         // SMA breakdown charts
 
         // cycle starts
         let marketCycleSection =
-            Constants.SMA20
+            SMA20
             |> Storage.getIndustryCycles
             |> Cycles.generateIndustryCycleStartChart
 

--- a/src/StockScreenerReports.Web/Handlers/Trends.fs
+++ b/src/StockScreenerReports.Web/Handlers/Trends.fs
@@ -65,7 +65,7 @@ module Trends =
                 {
                     data = breakdowns |> List.map (fun breakdown -> breakdown.percentAboveRounded)
                     title = $"SMA {sma}"
-                    color = sma |> Constants.mapSmaToColor 
+                    color = sma |> SMA.toColor 
                 }
             )
 
@@ -268,7 +268,7 @@ module Trends =
             ]::volumeCharts        
 
         let trends =
-            Constants.SMAS
+            SMA.all
             |> List.map(fun sma -> 
                 (sma, sma |> getDailySMABreakdown dateRange)
             )
@@ -309,7 +309,7 @@ module Trends =
                     None
                 | Some d ->
                     let dateToUse = d |> Utils.convertToDateString
-                    Constants.SMAS
+                    SMA.all
                     |> List.map (fun days -> days |> getIndustryTrendBreakdown dateToUse)
                     |> Some
                     
@@ -319,7 +319,7 @@ module Trends =
                     None
                 | Some d ->
                     let dateToUse = d |> Utils.convertToDateString
-                    Constants.SMA20 |> getIndustryTrends dateToUse |> Some
+                    SMA20 |> getIndustryTrends dateToUse |> Some
 
             let elementsToRender = generateElementsToRender missedJobs screeners industries upAndDowns dateRange
 

--- a/src/StockScreenerReports.Web/Services.fs
+++ b/src/StockScreenerReports.Web/Services.fs
@@ -85,7 +85,7 @@ module Services =
                 Storage.getCountries()
                 |> List.filter (fun country -> country <> "United States" && country <> "Costa Rica") // TODO: how do we filter out test data and outdated stocks?
             
-            let countrySmaPairs = countries |> Seq.map (fun country -> Constants.SMAS |> List.map (fun sma -> (country, sma))) |> Seq.concat
+            let countrySmaPairs = countries |> Seq.map (fun country -> SMA.all |> List.map (fun sma -> (country, sma))) |> Seq.concat
             
             let countriesUpdated =
                 countrySmaPairs
@@ -125,7 +125,7 @@ module Services =
             // pull above and below 20 and 200 for each industry, and store the results
             let knownIndustries = Storage.getIndustries()
             
-            let industrySmaPairs = knownIndustries |> Seq.map (fun industry -> Constants.SMAS |> List.map (fun sma -> (industry, sma))) |> Seq.concat
+            let industrySmaPairs = knownIndustries |> Seq.map (fun industry -> SMA.all |> List.map (fun sma -> (industry, sma))) |> Seq.concat
 
             let industriesUpdated =
                 industrySmaPairs
@@ -141,7 +141,7 @@ module Services =
                 )
                 |> Seq.length
 
-            Constants.SMAS |> List.iter (fun sma -> Storage.updateIndustrySMABreakdowns date sma |> ignore)
+            SMA.all |> List.iter (fun sma -> Storage.updateIndustrySMABreakdowns date sma |> ignore)
 
             logger.LogInformation($"Calculating trends")
 

--- a/tests/IndustryTrendsCalculatorTests.fs
+++ b/tests/IndustryTrendsCalculatorTests.fs
@@ -20,7 +20,7 @@ type IndustryTrendsCalculatorTests(output:ITestOutputHelper) =
                     above = above;
                     below = total - above;
                     date = ReportsConfig.now().AddDays(-list.Length).AddDays(index);
-                    days = Constants.SMA20;
+                    days = SMA20;
                 }
             }
         )

--- a/tests/ReportTests.fs
+++ b/tests/ReportTests.fs
@@ -234,12 +234,12 @@ type ReportTests() =
     [<Fact>]
     let ``industry sma breakdowns end to end works`` () =
         let date = "2022-04-01"
-        let days = 20
+        let sma = SMA20
 
-        Storage.saveIndustrySMABreakdowns date ("airlines",days,10,50)
+        Storage.saveIndustrySMABreakdowns date ("airlines",sma,10,50)
         |> ignore
 
-        let updates = date |> Reports.getIndustrySMABreakdowns days
+        let updates = date |> Reports.getIndustrySMABreakdowns sma
 
         updates.Length |> should equal 1
 
@@ -253,7 +253,7 @@ type ReportTests() =
     let ``latest industry sma breakdow works`` () =
         let update =
             StorageTests.testStockIndustry
-            |> Reports.getMostRecentIndustrySMABreakdown 20
+            |> Reports.getMostRecentIndustrySMABreakdown SMA20
 
         match update with
             | Some update ->
@@ -271,14 +271,14 @@ type ReportTests() =
         let dateRange = ReportsConfig.dateRangeAsStrings()
         let trends =
             StorageTests.testStockIndustry
-            |> Reports.getIndustrySMABreakdownsForIndustry 20 dateRange
+            |> Reports.getIndustrySMABreakdownsForIndustry SMA20 dateRange
         
         trends |> should not' (be Empty)
 
     [<Fact>]
     let ``get stock SMA breakdown works`` () =
         let breakdowns =
-            Constants.SMAS |> List.map (fun sma -> Reports.getStockSMABreakdown sma)
+            SMA.all |> List.map (fun sma -> Reports.getStockSMABreakdown sma)
 
         // we collapse tuples into array and check each member to be above 0
         breakdowns
@@ -302,7 +302,7 @@ type ReportTests() =
 
     [<Fact>]
     let ``get daily SMA breakdowns works`` () =
-        let results = Reports.getDailySMABreakdown (ReportsConfig.dateRangeAsStrings()) 20
+        let results = Reports.getDailySMABreakdown (ReportsConfig.dateRangeAsStrings()) SMA20
         results |> should not' (be Empty)
 
         // check order
@@ -316,7 +316,7 @@ type ReportTests() =
         let latestDate = Reports.getIndustrySMABreakdownLatestDate()
         let formattedDate = latestDate |> Utils.convertToDateString
 
-        let results = Constants.SMA200 |> Reports.getIndustryTrends formattedDate
+        let results = SMA200 |> Reports.getIndustryTrends formattedDate
         
         results |> should not' (be Empty)
 
@@ -330,7 +330,7 @@ type ReportTests() =
             |> Reports.getIndustryTrendsLastKnownDateAsOf 
             |> Option.get |> Utils.convertToDateString
 
-        Constants.SMAS
+        SMA.all
         |> List.iter (fun days ->
             let up, down = Reports.getIndustryTrendBreakdown dateToUse days
             up |> should be (greaterThan 0)
@@ -341,7 +341,7 @@ type ReportTests() =
     let ``calculate industry trends works`` () =
         let smaBreakdowns =
             StorageTests.testStockIndustry
-            |> Reports.getIndustrySMABreakdownsForIndustry 20 (ReportsConfig.dateRangeAsStrings())
+            |> Reports.getIndustrySMABreakdownsForIndustry SMA20 (ReportsConfig.dateRangeAsStrings())
         let trend = smaBreakdowns |> TrendsCalculator.calculateForIndustry |> getTrend
 
         trend.streak |> should be (greaterThan 0)
@@ -354,7 +354,7 @@ type ReportTests() =
     let ``get industry trend works`` () =
         let dateToUseOpt = ReportsConfig.dateRangeAsStrings() |> snd |> Reports.getIndustryTrendsLastKnownDateAsOf
         let dateToUse = dateToUseOpt |> Option.get |> Utils.convertToDateString
-        let trend = Reports.getIndustryTrend 20 dateToUse StorageTests.testStockIndustry
+        let trend = Reports.getIndustryTrend SMA20 dateToUse StorageTests.testStockIndustry
         trend.IsSome |> should be True
 
     [<Fact>]

--- a/tests/StorageTests.fs
+++ b/tests/StorageTests.fs
@@ -226,7 +226,7 @@ type StorageTests(output:ITestOutputHelper) =
 
         let date = Reports.getIndustrySMABreakdownLatestDate()
 
-        Constants.SMA20 |> Storage.updateIndustrySMABreakdowns (date |> Utils.convertToDateString) |> should equal 1
+        SMA20 |> Storage.updateIndustrySMABreakdowns (date |> Utils.convertToDateString) |> should equal 1
 
     [<Fact>]
     let ``updating industry trend works`` () =
@@ -243,7 +243,7 @@ type StorageTests(output:ITestOutputHelper) =
                 date = date;
                 above = 1;
                 below = 1;
-                days = 20;
+                days = SMA20;
             }
         }
 
@@ -256,14 +256,14 @@ type StorageTests(output:ITestOutputHelper) =
 
         let trendAndCycle =
             testStockIndustry
-            |> Reports.getIndustrySMABreakdownsForIndustry Constants.SMA20 range
+            |> Reports.getIndustrySMABreakdownsForIndustry SMA20 range
             |> TrendsCalculator.calculateForIndustry
         
         let cycle = trendAndCycle.cycle
 
-        Storage.saveIndustryCycle Constants.SMA20 cycle testStockIndustry |> ignore
+        Storage.saveIndustryCycle SMA20 cycle testStockIndustry |> ignore
 
-        let (industry, saved) = Storage.getIndustryCycle Constants.SMA20 testStockIndustry
+        let (industry, saved) = Storage.getIndustryCycle SMA20 testStockIndustry
 
         saved |> should equal cycle
         industry |> should equal testStockIndustry


### PR DESCRIPTION
I went through using hardcoded 20/200, to then using literal/constants but still with integers being passed through functions to now using discriminated unions and converted to/from integer on the edges. I could go with generic SMA of Integer but since I only care about 20/200 went with SMA20 and SMA200 cases. It feels like we could replace it with more generic version with ease now that this is in place.