### PR TITLE
Migrate background jobs to hangfire

### DIFF
--- a/src/StockScreenerReports.Web/Handlers/CorporateActions.fs
+++ b/src/StockScreenerReports.Web/Handlers/CorporateActions.fs
@@ -8,7 +8,7 @@ open StockScreenerReports.Core
 open Giraffe.ViewEngine.Attributes
 open Giraffe.ViewEngine.HtmlElements
 open StockScreenerReports.Storage
-open StockScreenerReports.Web.Services
+open StockScreenerReports.Web
 open StockScreenerReports.Web.Shared
 open StockScreenerReports.Web.Shared.Utils
 open StockScreenerReports.Web.Shared.Views

--- a/src/StockScreenerReports.Web/Handlers/Jobs.fs
+++ b/src/StockScreenerReports.Web/Handlers/Jobs.fs
@@ -1,36 +1,38 @@
 namespace StockScreenerReports.Web.Handlers
 
+open Giraffe
 open StockScreenerReports.Core
+open StockScreenerReports.Web
 open StockScreenerReports.Web.Shared.Utils
+open StockScreenerReports.Web.Shared
+
 
 module Jobs =
-    open StockScreenerReports.Web
-    open StockScreenerReports.Web.Shared.Utils
-    open Giraffe
-    open StockScreenerReports.Web.Shared
-
+    
     let logger = DummyLogger()
     
-    let private runWithLoggerAndRedirect url (func:DummyLogger -> System.Threading.Tasks.Task<JobStatus>) : HttpHandler =
+    let private runWithLoggerAndRedirect url (func:Services -> System.Threading.Tasks.Task<JobStatus>) : HttpHandler =
         fun (next : HttpFunc) (ctx : Microsoft.AspNetCore.Http.HttpContext) -> task {
-            let! _ = func logger // TODO: don't redirect if failed, show the failure
+            let services = ctx.GetService<Services>()
+            let! _ = func services
+            // TODO: don't redirect if failed, show the failure
             return! redirectTo false url next ctx
         }
 
     let screeners() =
-        Services.screenerRun |> runWithLoggerAndRedirect "/"
+        (fun (s:Services) -> s.ScreenerRun()) |> runWithLoggerAndRedirect "/"
 
     let trends() =
-        Services.trendsRun |> runWithLoggerAndRedirect Links.trends
+        (fun (s:Services) -> s.TrendsRun()) |> runWithLoggerAndRedirect Links.trends
         
     let countries() =
-        Services.countriesRun |> runWithLoggerAndRedirect Links.countries
+        (fun (s:Services) -> s.CountriesRun()) |> runWithLoggerAndRedirect Links.countries
 
     let earnings() =
-        Services.earningsRun |> runWithLoggerAndRedirect Links.earnings
+        (fun (s:Services) -> s.EarningsRun()) |> runWithLoggerAndRedirect Links.earnings
         
     let alerts() =
-        Services.alertsRun |> runWithLoggerAndRedirect Links.alerts
+        (fun (s:Services) -> s.AlertsRun()) |> runWithLoggerAndRedirect Links.alerts
         
     let corporateActions() =
-        Services.corporateActionsRun true |> runWithLoggerAndRedirect Links.corporateActions
+        (fun (s:Services) -> s.CorporateActionsRun true) |> runWithLoggerAndRedirect Links.corporateActions

--- a/src/StockScreenerReports.Web/Program.fs
+++ b/src/StockScreenerReports.Web/Program.fs
@@ -33,9 +33,6 @@ let configureCors (builder : CorsPolicyBuilder) =
        .AllowAnyMethod()
        .AllowAnyHeader()
        |> ignore
-       
-let myRecurringJob (services:Services) =
-    services.Test() :> Task
   
 let configureJobs (app : IApplicationBuilder) =
     let skipBackgroundJobs = Environment.GetEnvironmentVariable("SSR_SKIPBACKGROUNDJOBS")

--- a/src/StockScreenerReports.Web/Program.fs
+++ b/src/StockScreenerReports.Web/Program.fs
@@ -2,6 +2,10 @@ module StockScreenerReports.Web.App
 
 open System
 open System.IO
+open System.Linq.Expressions
+open System.Threading.Tasks
+open Hangfire
+open Hangfire.PostgreSql
 open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Cors.Infrastructure
@@ -10,8 +14,13 @@ open Microsoft.Extensions.Hosting
 open Microsoft.Extensions.Logging
 open Microsoft.Extensions.DependencyInjection
 open Giraffe
+open Microsoft.FSharp.Linq.RuntimeHelpers
+open StockScreenerReports.Core
 open StockScreenerReports.Storage
 
+// time functions return eastern timezone to match US market hours
+let easternTimeZone = TimeZoneConverter.TZConvert.GetTimeZoneInfo("Eastern Standard Time")    
+    
 let errorHandler (ex : Exception) (logger : ILogger) =
     logger.LogError(ex, "An unhandled exception has occurred while executing the request.")
     clearResponse >=> setStatusCode 500 >=> text ex.Message
@@ -24,6 +33,35 @@ let configureCors (builder : CorsPolicyBuilder) =
        .AllowAnyMethod()
        .AllowAnyHeader()
        |> ignore
+       
+let myRecurringJob (services:Services) =
+    services.Test() :> Task
+  
+let configureJobs (app : IApplicationBuilder) =
+    let skipBackgroundJobs = Environment.GetEnvironmentVariable("SSR_SKIPBACKGROUNDJOBS")
+    let logger = app.ApplicationServices.GetService<ILogger<Services>>()
+    match skipBackgroundJobs with
+    | "true" ->
+        logger.LogInformation("Skipping background jobs")
+    | _  ->
+        logger.LogInformation("Configuring background jobs")
+        
+        let rjo = RecurringJobOptions()
+        rjo.TimeZone <- easternTimeZone
+        
+        // at 16:30 eastern time we will run full background job
+        let s = app.ApplicationServices.GetService<Services>()
+        let fullRunExpression = <@ s.FullRun() @> |> LeafExpressionConverter.QuotationToExpression
+        let result = Expression.Lambda<Func<Task>>(fullRunExpression)
+        
+        RecurringJob.AddOrUpdate(
+            recurringJobId="fullrun",
+            methodCall=result,
+            cronExpression=Cron.Daily(17, 00),
+            options=rjo
+        )
+        
+        logger.LogInformation("Starting background jobs")
 
 let configureApp (app : IApplicationBuilder) =
     let env = app.ApplicationServices.GetService<IWebHostEnvironment>()
@@ -31,13 +69,15 @@ let configureApp (app : IApplicationBuilder) =
     | true  ->
         app.UseDeveloperExceptionPage()
     | false ->
-        app .UseGiraffeErrorHandler(errorHandler)
+        app.UseGiraffeErrorHandler(errorHandler)
             .UseHttpsRedirection())
         .UseCors(configureCors)
         .UseStaticFiles()
         .UseAuthentication()
         .UseAuthorization()
         .UseGiraffe(Router.routes)
+        
+    configureJobs app 
 
 let configureServices (services : IServiceCollection) =
     services.AddCors()    |> ignore
@@ -46,21 +86,24 @@ let configureServices (services : IServiceCollection) =
     services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
         .AddCookie() |> ignore
     services.AddAuthorization() |> ignore
-
+    
     let cnnString = Environment.GetEnvironmentVariable("SSR_CONNECTIONSTRING")
     cnnString |> Storage.configureConnectionString
     cnnString |> Reports.configureConnectionString
+    
+    let configAction = Action<PostgreSqlBootstrapperOptions>(fun options ->
+        options.UseNpgsqlConnection(cnnString) |> ignore
+    )
+    
+    GlobalConfiguration.Configuration.UsePostgreSqlStorage(configAction) |> ignore
+    
+    services.AddSingleton<Services>() |> ignore
+    services.AddHangfire(fun c -> ()) |> ignore
+    services.AddHangfireServer() |> ignore
 
-    // we also need to make sure the date is returned in easter timezone
-    let easternTimeZone = TimeZoneConverter.TZConvert.GetTimeZoneInfo("Eastern Standard Time")
-    StockScreenerReports.Core.TimeFunctions.nowFunc <- fun () ->
+    TimeFunctions.nowFunc <- fun () ->
         let now = DateTime.UtcNow
         TimeZoneInfo.ConvertTimeFromUtc(now, easternTimeZone)
-
-    let skipBackgroundJobs = Environment.GetEnvironmentVariable("SSR_SKIPBACKGROUNDJOBS")
-    match skipBackgroundJobs with
-    | "true" -> System.Console.WriteLine("Skipping background jobs") |> ignore
-    | _  -> services.AddHostedService<Services.BackgroundService>() |> ignore 
 
 let configureLogging (builder : ILoggingBuilder) =
     builder.AddConsole()
@@ -76,9 +119,9 @@ let main args =
                 webHostBuilder
                     .UseContentRoot(contentRoot)
                     .UseWebRoot(webRoot)
+                    .ConfigureLogging(configureLogging)
                     .Configure(Action<IApplicationBuilder> configureApp)
                     .ConfigureServices(configureServices)
-                    .ConfigureLogging(configureLogging)
                     |> ignore)
         .Build()
         .Run()

--- a/src/StockScreenerReports.Web/Services.fs
+++ b/src/StockScreenerReports.Web/Services.fs
@@ -1,13 +1,17 @@
 namespace StockScreenerReports.Web
 
-module Services =
-    open StockScreenerReports.Storage
-    open Microsoft.Extensions.Logging
-    open StockScreenerReports.Core
-    open StockScreenerReports.FinvizClient
-    open System
-    open System.Collections.Generic
+open StockScreenerReports.Storage
+open Microsoft.Extensions.Logging
+open StockScreenerReports.Core
+open StockScreenerReports.FinvizClient
+open System
+open System.Collections.Generic
 
+type Services(logger:ILogger<Services>) = 
+    
+    let runTracker = HashSet<string>()
+
+    
     let runIfTradingDay forced func = task {
         let isTradingDay = ReportsConfig.now().Date |> ReportsConfig.isTradingDay
         
@@ -16,7 +20,7 @@ module Services =
         | false -> return Skipped
     }
 
-    let screenerRun (logger:ILogger) =
+    member _.ScreenerRun() =
         let fetchScreenerResults (input:Screener) =
             logger.LogInformation $"Running screener %s{input.name}"
             let results = FinvizClient.getResults input.url
@@ -59,7 +63,7 @@ module Services =
         
         runIfTradingDay false funcToRun
 
-    let earningsRun (logger:ILogger) =
+    member _.EarningsRun() =
         
         let funcToRun() = task {
             let earnings = FinvizClient.getEarnings()
@@ -83,7 +87,7 @@ module Services =
         
         runIfTradingDay false funcToRun
         
-    let corporateActionsRun forced (_:ILogger) =
+    member _.CorporateActionsRun forced =
         let funcToRun() = task {
             try
                 let actions = StockAnalysisClient.getCorporateActions()
@@ -111,7 +115,7 @@ module Services =
         
         runIfTradingDay forced funcToRun
     
-    let alertsRun (logger:ILogger) =
+    member _.AlertsRun() =
         
         let funcToRun() = task {
             
@@ -196,7 +200,7 @@ module Services =
         
         runIfTradingDay false funcToRun
 
-    let countriesRun (logger:ILogger) =
+    member _.CountriesRun() =
         
         let funcToRun () = task {
             
@@ -235,8 +239,16 @@ module Services =
         }
         
         runIfTradingDay false funcToRun
-            
-    let trendsRun (logger:ILogger) =
+    
+    member _.Test() =
+        let funcToRun() = task {
+            logger.LogInformation("Running test")
+            return Success
+        }
+        
+        runIfTradingDay false funcToRun
+    
+    member _.TrendsRun() =
         let funcToRun() = task {
             let date = Utils.getRunDate()
 
@@ -300,124 +312,86 @@ module Services =
         }
         
         runIfTradingDay false funcToRun
-
-    type CorporateActionProcessor(logger:ILogger<CorporateActionProcessor>) =
         
-        member this.BankruptyDelistings() = task {
-            
-            // actions for the day
-            let! actions = Storage.getCorporateActions()
-            
-            // group it by symbol
-            let actionsBySymbol = actions |> List.groupBy (fun a -> a.Symbol,a.Date)
-            
-            // go over each group, and the group that has Delisted and symbol change, take the old symbol and delete it from our db
-            let stocksToDelete =
-                actionsBySymbol
-                |> List.map (fun (_, actions) ->
-                    let delisted = actions |> List.tryFind (fun x -> x.Type = Delisted)
-                    let symbolChange = actions |> List.tryFind (fun x -> match x.Type with | SymbolChange _ -> true | _ -> false)
-                    let bankrupcy = actions |> List.tryFind (fun x -> x.Type = Bankruptcy)
-                    (delisted, symbolChange, bankrupcy)
-                )
-                |> List.filter (fun (delisted, symbolChange, bankruptcy) -> delisted.IsSome && symbolChange.IsSome && bankruptcy.IsSome)
-                |> List.map (fun (_, symbolChange, _) -> match symbolChange.Value.Type with | SymbolChange(oldSymbol, _) -> oldSymbol | _ -> failwith "Invalid symbol change")
-                |> List.map (fun x -> x |> StockTicker.create |> Storage.getStockByTicker)
-                |> List.choose id
+    member this.FullRun() = task {
+        try
+            logger.LogInformation("Full run")
+            let runDate = Utils.getRunDate()
+            if runTracker.Contains(runDate) then
+                logger.LogInformation("Already ran today")
+            else
+                logger.LogInformation("Running")
+                runTracker.Add(runDate) |> ignore
                 
-            let recordsDeleted =
-                stocksToDelete
-                |> List.map Storage.deleteStock
-                |> List.concat
-                |> List.sum
+                let! _ = this.ScreenerRun()
+                let! _ = this.EarningsRun()
+                let! _ = this.TrendsRun()
+                let! _ = this.CountriesRun()
+                let! _ = this.CorporateActionsRun false
+                let! _ = this.AlertsRun()
+                
+                logger.LogInformation("Finished full run")
+        with
+        | ex -> logger.LogError(ex, "Error running background service")
+}
 
-            return stocksToDelete, recordsDeleted
-        }
+type CorporateActionProcessor(logger:ILogger<CorporateActionProcessor>) =    
+    member this.BankruptyDelistings() = task {
         
-        member this.Delistings() = task {
+        // actions for the day
+        let! actions = Storage.getCorporateActions()
+        
+        // group it by symbol
+        let actionsBySymbol = actions |> List.groupBy (fun a -> a.Symbol,a.Date)
+        
+        // go over each group, and the group that has Delisted and symbol change, take the old symbol and delete it from our db
+        let stocksToDelete =
+            actionsBySymbol
+            |> List.map (fun (_, actions) ->
+                let delisted = actions |> List.tryFind (fun x -> x.Type = Delisted)
+                let symbolChange = actions |> List.tryFind (fun x -> match x.Type with | SymbolChange _ -> true | _ -> false)
+                let bankrupcy = actions |> List.tryFind (fun x -> x.Type = Bankruptcy)
+                (delisted, symbolChange, bankrupcy)
+            )
+            |> List.filter (fun (delisted, symbolChange, bankruptcy) -> delisted.IsSome && symbolChange.IsSome && bankruptcy.IsSome)
+            |> List.map (fun (_, symbolChange, _) -> match symbolChange.Value.Type with | SymbolChange(oldSymbol, _) -> oldSymbol | _ -> failwith "Invalid symbol change")
+            |> List.map (fun x -> x |> StockTicker.create |> Storage.getStockByTicker)
+            |> List.choose id
             
-            // actions
-            let! actions = Storage.getCorporateActions()
+        let recordsDeleted =
+            stocksToDelete
+            |> List.map Storage.deleteStock
+            |> List.concat
+            |> List.sum
+
+        return stocksToDelete, recordsDeleted
+    }
+    
+    member this.Delistings() = task {
+        
+        // actions
+        let! actions = Storage.getCorporateActions()
+        
+        // group it by symbol and date
+        let actionsBySymbol = actions |> List.groupBy (fun a -> a.Symbol,a.Date)
+        
+        // go over each group, and the group that has Delisted ONLY, can be used for deletion
+        let stocksToDelete =
+            actionsBySymbol
+            |> List.map (fun (_, actions) ->
+                let delisted = actions |> List.tryFind (fun x -> x.Type = Delisted)
+                delisted, actions.Length
+            )
+            |> List.filter (fun (delisted, count) -> delisted.IsSome && count = 1)
+            |> List.map (fun (delisted, _) -> delisted.Value.Symbol)
+            |> List.map (fun x -> x |> StockTicker.create |> Storage.getStockByTicker)
+            |> List.choose id
             
-            // group it by symbol and date
-            let actionsBySymbol = actions |> List.groupBy (fun a -> a.Symbol,a.Date)
-            
-            // go over each group, and the group that has Delisted ONLY, can be used for deletion
-            let stocksToDelete =
-                actionsBySymbol
-                |> List.map (fun (_, actions) ->
-                    let delisted = actions |> List.tryFind (fun x -> x.Type = Delisted)
-                    delisted, actions.Length
-                )
-                |> List.filter (fun (delisted, count) -> delisted.IsSome && count = 1)
-                |> List.map (fun (delisted, _) -> delisted.Value.Symbol)
-                |> List.map (fun x -> x |> StockTicker.create |> Storage.getStockByTicker)
-                |> List.choose id
-                
-            let recordsDeleted =
-                stocksToDelete
-                |> List.map Storage.deleteStock
-                |> List.concat
-                |> List.sum
+        let recordsDeleted =
+            stocksToDelete
+            |> List.map Storage.deleteStock
+            |> List.concat
+            |> List.sum
 
-            return stocksToDelete, recordsDeleted
-        }
-            
-    // background service class
-    type BackgroundService(logger:ILogger<BackgroundService>) =
-        inherit Microsoft.Extensions.Hosting.BackgroundService()
-
-        let runTracker = HashSet<string>()
-
-        let doSleepInternal (sleepTime:int) =
-            logger.LogInformation($"Sleeping for {sleepTime} milliseconds")
-            System.Threading.Tasks.Task.Delay(sleepTime)
-            
-        let doSleep() =
-            60 * 60 * 1000 |> doSleepInternal
-
-        let shortSleep() =
-            10 * 1000 |> doSleepInternal
-
-        override _.ExecuteAsync(cancellationToken) =
-            task {
-                while cancellationToken.IsCancellationRequested |> not do
-                        
-                logger.LogInformation("---- background service")
-                let now = ReportsConfig.now()
-                let time = now.TimeOfDay
-                let marketClose = TimeSpan(16,0,0)
-                let marketCloseDelayed = marketClose.Add(TimeSpan.FromMinutes(30))
-                if runTracker.Count = 0 then
-                    logger.LogInformation("Run tracker is empty, warming up")
-                    runTracker.Add("warmup") |> ignore
-                    let! _ = shortSleep()
-                    logger.LogInformation("Short sleep finished")
-                else if time < marketCloseDelayed then
-                    logger.LogInformation("Not past market close time")
-                    let! _ = doSleep()
-                    logger.LogInformation("Finished sleeping")
-                else
-                    try
-                        logger.LogInformation("Past market close, checking if already ran today")
-                        let runDate = Utils.getRunDate()
-                        if runTracker.Contains(runDate) then
-                            logger.LogInformation("Already ran today")
-                        else
-                            logger.LogInformation("Running")
-                            runTracker.Add(runDate) |> ignore
-                            
-                            let! _ = screenerRun logger
-                            let! _ = earningsRun logger
-                            let! _ = trendsRun logger
-                            let! _ = countriesRun logger
-                            let! _ = corporateActionsRun false logger
-                            let! _ = alertsRun logger
-                            logger.LogInformation("Finished running")
-                    with
-                    | ex -> logger.LogError(ex, "Error running background service")
-
-                    let! _ = doSleep()
-
-                    logger.LogInformation("Finished sleeping")
-            }
+        return stocksToDelete, recordsDeleted
+    }

--- a/src/StockScreenerReports.Web/StockScreenerReports.Web.fsproj
+++ b/src/StockScreenerReports.Web/StockScreenerReports.Web.fsproj
@@ -10,6 +10,8 @@
     <PackageReference Include="FSharp.Data" Version="6.4.0" />
     <PackageReference Include="Giraffe" Version="6.4.0" />
     <PackageReference Include="Giraffe.ViewEngine" Version="1.4.0" />
+    <PackageReference Include="Hangfire" Version="1.8.14" />
+    <PackageReference Include="Hangfire.PostgreSql" Version="1.20.9" />
     <PackageReference Include="MathNet.Numerics" Version="6.0.0-beta1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />


### PR DESCRIPTION
Ditch the custom background job and move it to hangfire.

End of day job does look like it could benefit from being split up into separate jobs eventually, but leaving it as is to port it without functionality changes and only infra changes in here.